### PR TITLE
Indentation

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -82,22 +82,17 @@ for version in "${versions[@]}"; do
 	cat >> Dockerfile <<-EOF
 		# a few minor docker-specific tweaks
 		# see https://github.com/docker/docker/blob/master/contrib/mkimage/debootstrap
-		RUN echo '#!/bin/sh' > /usr/sbin/policy-rc.d \
-		  && echo 'exit 101' >> /usr/sbin/policy-rc.d \
-		  && chmod +x /usr/sbin/policy-rc.d \
-		  \
-		  && dpkg-divert --local --rename --add /sbin/initctl \
-		  && cp -a /usr/sbin/policy-rc.d /sbin/initctl \
-		  && sed -i 's/^exit.*/exit 0/' /sbin/initctl \
-		  \
-		  && echo 'force-unsafe-io' > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup \
-		  \
-		  && echo 'DPkg::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' > /etc/apt/apt.conf.d/docker-clean \
-		  && echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> /etc/apt/apt.conf.d/docker-clean \
-		  && echo 'Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";' >> /etc/apt/apt.conf.d/docker-clean \
-		  \
-		  && echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/docker-no-languages \
-		  \
+		RUN echo '#!/bin/sh' > /usr/sbin/policy-rc.d \\
+		  && echo 'exit 101' >> /usr/sbin/policy-rc.d \\
+		  && chmod +x /usr/sbin/policy-rc.d \\
+		  && dpkg-divert --local --rename --add /sbin/initctl \\
+		  && cp -a /usr/sbin/policy-rc.d /sbin/initctl \\
+		  && sed -i 's/^exit.*/exit 0/' /sbin/initctl \\
+		  && echo 'force-unsafe-io' > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup \\
+		  && echo 'DPkg::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' > /etc/apt/apt.conf.d/docker-clean \\
+		  && echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> /etc/apt/apt.conf.d/docker-clean \\
+		  && echo 'Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";' >> /etc/apt/apt.conf.d/docker-clean \\
+		  && echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/docker-no-languages \\
 		  && echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/docker-gzip-indexes
 
 		# enable the universe

--- a/update.sh
+++ b/update.sh
@@ -62,52 +62,50 @@ for version in "${versions[@]}"; do
 			exit 1
 		fi
 	fi
-	cat > Dockerfile <<EOF
-FROM scratch
-ADD $thisTar /
+	cat > Dockerfile <<-EOF
+		FROM scratch
+		ADD $thisTar /
 
-ENV ARCH=${arch} UBUNTU_SUITE=${v} DOCKER_REPO=${repo}
-EOF
+		ENV ARCH=${arch} UBUNTU_SUITE=${v} DOCKER_REPO=${repo}
+	EOF
 
 	if [ -n "${qemu_arch}" ]; then
 		if [ ! -f x86_64_qemu-${qemu_arch}-static.tar.gz ]; then
 			wget -N https://github.com/multiarch/qemu-user-static/releases/download/v2.6.0/x86_64_qemu-${qemu_arch}-static.tar.gz
 		fi
-		cat >> Dockerfile <<EOF
-
-# Add qemu-user-static binary for amd64 builders
-ADD x86_64_qemu-${qemu_arch}-static.tar.gz /usr/bin
-EOF
+		cat >> Dockerfile <<-EOF
+			# Add qemu-user-static binary for amd64 builders
+			ADD x86_64_qemu-${qemu_arch}-static.tar.gz /usr/bin
+		EOF
 	fi
 
-	cat >> Dockerfile <<EOF
+	cat >> Dockerfile <<-EOF
+		# a few minor docker-specific tweaks
+		# see https://github.com/docker/docker/blob/master/contrib/mkimage/debootstrap
+		RUN echo '#!/bin/sh' > /usr/sbin/policy-rc.d \
+		  && echo 'exit 101' >> /usr/sbin/policy-rc.d \
+		  && chmod +x /usr/sbin/policy-rc.d \
+		  \
+		  && dpkg-divert --local --rename --add /sbin/initctl \
+		  && cp -a /usr/sbin/policy-rc.d /sbin/initctl \
+		  && sed -i 's/^exit.*/exit 0/' /sbin/initctl \
+		  \
+		  && echo 'force-unsafe-io' > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup \
+		  \
+		  && echo 'DPkg::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' > /etc/apt/apt.conf.d/docker-clean \
+		  && echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> /etc/apt/apt.conf.d/docker-clean \
+		  && echo 'Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";' >> /etc/apt/apt.conf.d/docker-clean \
+		  \
+		  && echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/docker-no-languages \
+		  \
+		  && echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/docker-gzip-indexes
 
-# a few minor docker-specific tweaks
-# see https://github.com/docker/docker/blob/master/contrib/mkimage/debootstrap
-RUN echo '#!/bin/sh' > /usr/sbin/policy-rc.d \
-	&& echo 'exit 101' >> /usr/sbin/policy-rc.d \
-	&& chmod +x /usr/sbin/policy-rc.d \
-	\
-	&& dpkg-divert --local --rename --add /sbin/initctl \
-	&& cp -a /usr/sbin/policy-rc.d /sbin/initctl \
-	&& sed -i 's/^exit.*/exit 0/' /sbin/initctl \
-	\
-	&& echo 'force-unsafe-io' > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup \
-	\
-	&& echo 'DPkg::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' > /etc/apt/apt.conf.d/docker-clean \
-	&& echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> /etc/apt/apt.conf.d/docker-clean \
-	&& echo 'Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";' >> /etc/apt/apt.conf.d/docker-clean \
-	\
-	&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/docker-no-languages \
-	\
-	&& echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/docker-gzip-indexes
+		# enable the universe
+		RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list
 
-# enable the universe
-RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list
-
-# overwrite this with 'CMD []' in a dependent Dockerfile
-CMD ["/bin/bash"]
-EOF
+		# overwrite this with 'CMD []' in a dependent Dockerfile
+		CMD ["/bin/bash"]
+	EOF
 	)
 done
 


### PR DESCRIPTION
1. commit: general indentation fixes (this script was indented with spaces and tabs on the same line)
2. commit: now, why I actually wanted to create this PR: indent the bash-here-strings
    - If using `<<-EOF` instead of `<<EOF` it is possible to indent them with tabs inside the script and still use spaces to indent the actual string.
3. commit: A small bit I've seen: the `RUN`-command in the generated dockerfiles are all one long string, because the end-of-line backslash actually gets interpreted inside bash are not printed into the dockerfile.