### PR TITLE
feat: adds i386 and amd64 tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,25 +15,34 @@ env:
     matrix:
         - ARCH=i386      VERSION=trusty    QEMU_ARCH=i386      TAG_ARCH=x86
         - ARCH=amd64     VERSION=trusty    QEMU_ARCH=x86_64    TAG_ARCH=x86_64
+        - ARCH=i386      VERSION=trusty    QEMU_ARCH=i386      TAG_ARCH=i386
+        - ARCH=amd64     VERSION=trusty    QEMU_ARCH=x86_64    TAG_ARCH=amd64
         - ARCH=armhf     VERSION=trusty    QEMU_ARCH=arm       TAG_ARCH=armhf
         - ARCH=arm64     VERSION=trusty    QEMU_ARCH=aarch64   TAG_ARCH=arm64
 
         - ARCH=i386      VERSION=xenial    QEMU_ARCH=i386      TAG_ARCH=x86
         - ARCH=amd64     VERSION=xenial    QEMU_ARCH=x86_64    TAG_ARCH=x86_64
+        - ARCH=i386      VERSION=xenial    QEMU_ARCH=i386      TAG_ARCH=i386
+        - ARCH=amd64     VERSION=xenial    QEMU_ARCH=x86_64    TAG_ARCH=amd64
         - ARCH=armhf     VERSION=xenial    QEMU_ARCH=arm       TAG_ARCH=armhf
         - ARCH=arm64     VERSION=xenial    QEMU_ARCH=aarch64   TAG_ARCH=arm64
 
         - ARCH=i386      VERSION=bionic    QEMU_ARCH=i386      TAG_ARCH=x86
         - ARCH=amd64     VERSION=bionic    QEMU_ARCH=x86_64    TAG_ARCH=x86_64
+        - ARCH=i386      VERSION=bionic    QEMU_ARCH=i386      TAG_ARCH=i386
+        - ARCH=amd64     VERSION=bionic    QEMU_ARCH=x86_64    TAG_ARCH=amd64
         - ARCH=armhf     VERSION=bionic    QEMU_ARCH=arm       TAG_ARCH=armhf
         - ARCH=arm64     VERSION=bionic    QEMU_ARCH=aarch64   TAG_ARCH=arm64
 
         - ARCH=i386      VERSION=eoan      QEMU_ARCH=i386      TAG_ARCH=x86
-        - ARCH=amd64     VERSION=eoan      QEMU_ARCH=x86_64    TAG_ARCH=x86_64
+        - ARCH=amd64     VERSION=eoan      QEMU_ARCH=x86_64    TAG_ARCH=x86_64      
+        - ARCH=i386      VERSION=eoan      QEMU_ARCH=i386      TAG_ARCH=i386
+        - ARCH=amd64     VERSION=eoan      QEMU_ARCH=x86_64    TAG_ARCH=amd64
         - ARCH=armhf     VERSION=eoan      QEMU_ARCH=arm       TAG_ARCH=armhf
         - ARCH=arm64     VERSION=eoan      QEMU_ARCH=aarch64   TAG_ARCH=arm64
 
         - ARCH=amd64     VERSION=focal     QEMU_ARCH=x86_64    TAG_ARCH=x86_64
+        - ARCH=amd64     VERSION=focal     QEMU_ARCH=x86_64    TAG_ARCH=amd64
         - ARCH=armhf     VERSION=focal     QEMU_ARCH=arm       TAG_ARCH=armhf
         - ARCH=arm64     VERSION=focal     QEMU_ARCH=aarch64   TAG_ARCH=arm64
 script:


### PR DESCRIPTION
Adds the `amd64` and `i386` tags like `multiarch/alpine` has:
https://github.com/multiarch/alpine/blob/master/.travis.yml